### PR TITLE
Updates example in readme that references an outdated variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ We could imagine another specification of the `current_age_for_birth_year` metho
 
 ```ruby
 it "should return the current year for a person born in year 0" do
-  twenty_sixteen = current_age_for_birth_year(0)
+  current_year = current_age_for_birth_year(0)
 
-  expect(twenty_sixteen).to eq(2003)
+  expect(current_year).to eq(2003)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ We could imagine another specification of the `current_age_for_birth_year` metho
 
 ```ruby
 it "should return the current year for a person born in year 0" do
-  current_year = current_age_for_birth_year(0)
+  age = current_age_for_birth_year(0)
 
-  expect(current_year).to eq(2003)
+  expect(age).to eq(2003)
 end
 ```
 


### PR DESCRIPTION
issue #56: I went through this lesson step-by-step and it does actually work as is. The solution branch has the answer for abstracting the tests and the method. In the lesson, it only requires the student to get the tests passing with a method that has a hardcoded year in it. The issue states that it only works with 2016 when we are in 2018. This lesson doesn't say anything about 2016 anymore. Most of that has been removed. It changed the year to 2003. If you actually write 2003, the test passes. So I don't know where the confusion lies unless they are somehow seeing old content. That being said, I updated an old variable so there's no confusion about the year.